### PR TITLE
Add panner

### DIFF
--- a/src/components/controls/Knob.svelte
+++ b/src/components/controls/Knob.svelte
@@ -6,8 +6,9 @@
   export let id: string
   export let label: string
   export let polarity: 'unipolar' | 'bipolar' = 'unipolar'
-  export let min: number = polarity === 'unipolar' ? 0 : -50
-  export let max: number = polarity === 'unipolar' ? 100 : 50
+  export let min: number = polarity === 'unipolar' ? 0 : -100
+  export let max: number = polarity === 'unipolar' ? 100 : 100
+  export let value: number = polarity === 'unipolar' ? 50 : 0
 
   const dispatch = createEventDispatcher()
 
@@ -19,7 +20,9 @@
   let knobSource = setKnobSource($theme)
 
   const setValue = (event: { type: string; target: HTMLInputElement }) => {
-    const { value } = event.target
+    const { value: val } = event.target
+
+    value = +val
 
     switch (event.type) {
       case 'input':
@@ -62,6 +65,7 @@
     src={knobSource}
     {min}
     {max}
+    {value}
     on:input={setValue}
     on:change={setValue}
   />

--- a/src/lib/common/utils.ts
+++ b/src/lib/common/utils.ts
@@ -5,3 +5,11 @@ export const halve = <T>(array: T[]): { firstHalf: T[]; secondHalf: T[] } => {
 
   return { firstHalf, secondHalf }
 }
+
+export const translateToRange = ({ num, original, scaled }: {
+  num: number
+  original: { min: number; max: number }
+  scaled: { min: number; max: number }
+}): number => {
+  return ((scaled.max - scaled.min) * (num - original.min)) / (original.max - original.min) + scaled.min
+}

--- a/src/lib/engine/index.ts
+++ b/src/lib/engine/index.ts
@@ -4,7 +4,7 @@ import WebRenderer from '@elemaudio/web-renderer-lite'
 
 import { engineStore } from '../../stores'
 
-import type { NodeRepr_t } from '@elemaudio/core'
+import type { Channels } from '$lib/instruments'
 
 export class Engine {
   constructor() {
@@ -33,7 +33,7 @@ export class Engine {
     const node = await core.initialize(context, {
       numberOfInputs: 0,
       numberOfOutputs: 1,
-      outputChannelCount: [3],
+      outputChannelCount: [2],
     })
 
     node.connect(context.destination)
@@ -53,14 +53,15 @@ export class Engine {
     engineStore.update(store => ({ ...store, context }))
   }
 
-  render = (ensemble: number | NodeRepr_t): void => {
+  render = (channels: Channels): void => {
     const { context, core, elementaryReady } = get(engineStore)
 
     if (elementaryReady && context.state === 'running') {
-      const dcblockOut = el.dcblock(ensemble)
-      const gainOut = el.mul(dcblockOut, 3)
+      const leftBlockedOut = el.dcblock(channels.left)
+      const rightBlockedOut = el.dcblock(channels.right)
 
-      core.render(gainOut, gainOut)
+      core.render(leftBlockedOut, rightBlockedOut)
+
     }
   }
 }

--- a/src/lib/instruments/index.ts
+++ b/src/lib/instruments/index.ts
@@ -1,9 +1,13 @@
+import type { NodeRepr_t } from '@elemaudio/core'
+
 import { tune } from '$lib/tuning'
 
 export type Config = {
   selectedController: 'keyboard' | 'midi' | 'none'
   keyboardStatus: 'playing' | 'typing'
 }
+
+export type Channels = { left: NodeRepr_t | number; right: NodeRepr_t | number }
 
 export type Voice = { gate: number; freq: number; key: string }
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
 
-  import type { NodeRepr_t } from '@elemaudio/core'
   import type { NoteEventMap } from '$lib/controllers'
   import type * as instrument from '$lib/instruments'
 
@@ -36,10 +35,10 @@
     await engine.suspendAudio()
   }
 
-  const render = (event: CustomEvent<{ node: number | NodeRepr_t }>) => {
-    const { node } = event.detail
+  const render = (event: CustomEvent<{ channels: instrument.Channels }>) => {
+    const { channels } = event.detail
 
-    engine.render(node)
+    engine.render(channels)
   }
 
   const setController = (event: CustomEvent<{ controller: string }>) => {


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Add a panning
* [x] Convert render to accept `Channels`
* [x] Add `translateToRange` helper function
* [x] Update `Knob` to accept an initial value

The UI control and synth have different concepts of range for panning. In the UI, panning can be set to a value in the range [-100,100], but in the synth we use the range [0,1]. The component is responsible to converting pan values to the range defined by the synth in its limits:

https://github.com/bgins/svelte-elementary-template/blob/305c36d67c42084952a51ebb8c4d494eaab9e551/src/lib/instruments/base-synth.ts#L22-L24

The `translateToRange` function provides a convenient way to do this conversion.